### PR TITLE
Add shutdown to ThreadPool

### DIFF
--- a/ThreadPoolCpp11/ThreadPool.h
+++ b/ThreadPoolCpp11/ThreadPool.h
@@ -107,10 +107,18 @@ namespace zl
                             return;
                         task = std::move(this->tasks_.front());
                         this->tasks_.pop();
+                        this->cond_.notify_one();
                     }
                     task();
                 }
             }));
+        }
+    }
+
+    void shutdown() {
+        std::unique_lock<std::mutex> ulk(mtx_);
+        cond_.wait(ulk, [this] {
+            return this->tasks_.empty();
         }
     }
 


### PR DESCRIPTION
`shutdown()` will wait until tasks is empty. `ThreadPool` do some destructing directly if process will exit.